### PR TITLE
Update Cake 4.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "~4.0.0",
+        "cakephp/cakephp": "^4.0.0",
         "apereo/phpcas": "~1.4.0"
     },
     "require-dev": {

--- a/src/Auth/CasAuthenticate.php
+++ b/src/Auth/CasAuthenticate.php
@@ -54,7 +54,8 @@ class CasAuthenticate extends BaseAuthenticate
         $settings = $this->getConfig();
 
         if (!empty($settings['debug'])) {
-            phpCAS::setDebug(LOGS . 'phpCas.log');
+            //phpCAS::setDebug(LOGS . 'phpCas.log');
+            phpCAS::setLogger();
         }
 
         //The "isInitialized" check isn't necessary during normal use,
@@ -166,7 +167,7 @@ class CasAuthenticate extends BaseAuthenticate
     /**
      * {@inheritDoc}
      */
-    public function implementedEvents()
+    public function implementedEvents(): array
     {
         return ['Auth.logout' => 'logout'];
     }


### PR DESCRIPTION
Updates cakephp dependency declaration in composer.json.
Fix deprecation of phpCAS::setDebug()

closes #1