### PR TITLE
Maint: Update min version of phpCAS to 1.6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+
+[*.feature]
+indent_size = 3
+
+[*.hbs]
+insert_final_newline = false
+
+[*.php]
+indent_size = 4
+insert_final_newline = false
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ And run `php composer.phar update`
 
 Load the Cake AuthComponent, including CasAuth.Cas as an authenticator.
 For example:
+
 ```php
 $this->loadComponent('Auth');
 
@@ -40,6 +41,7 @@ $this->Auth->config(
 ```
 
 Or combine the load and configuration into one step:
+
 ```php
 $this->loadComponent(
     'Auth',
@@ -67,9 +69,11 @@ Configure::write('CAS.port', 8443);
 * **hostname** is required
 * **port** defaults to 443
 * **uri** defaults to '' (an empty string)
+* *client_name* (optional) defaults to `$_SERVER['SERVER_NAME']`
 * *debug* (optional) if true, then phpCAS will write debug info to logs/phpCAS.log
 * *cert_path* (optional) if set, then phpCAS will use the specified CA certificate file to verify the CAS server
 * *curlopts* (optional) key/value paired array of additional CURL parameters to pass through to phpCAS::setExtraCurlOption, e.g.
+
 ```php
 'curlopts' => [CURLOPT_PROXY => 'http://proxy:5543', CURLOPT_CRLF => true]
 ```

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "^4.0.0",
-        "apereo/phpcas": "~1.4.0"
+        "cakephp/cakephp": "^4.0",
+        "apereo/phpcas": "^1.6"
     },
     "require-dev": {
     },

--- a/src/Auth/CasAuthenticate.php
+++ b/src/Auth/CasAuthenticate.php
@@ -37,7 +37,8 @@ class CasAuthenticate extends BaseAuthenticate
     protected $_defaultConfig = [
         'hostname' => null,
         'port' => 443,
-        'uri' => ''
+        'uri' => '',
+        'client_name' => null,
     ];
 
     /**
@@ -54,8 +55,11 @@ class CasAuthenticate extends BaseAuthenticate
         $settings = $this->getConfig();
 
         if (!empty($settings['debug'])) {
-            //phpCAS::setDebug(LOGS . 'phpCas.log');
             phpCAS::setLogger();
+        }
+
+        if (empty($settings['client_name'])) {
+            $settings['client_name'] = $_SERVER['SERVER_NAME'];
         }
 
         //The "isInitialized" check isn't necessary during normal use,
@@ -63,7 +67,13 @@ class CasAuthenticate extends BaseAuthenticate
         //the fact that phpCAS uses a static global initialization can
         //cause problems
         if (!phpCAS::isInitialized()) {
-            phpCAS::client(CAS_VERSION_2_0, $settings['hostname'], $settings['port'], $settings['uri']);
+          phpCAS::client(
+            CAS_VERSION_2_0,
+            $settings['hostname'],
+            $settings['port'],
+            $settings['uri'],
+            $settings['client_name'],
+          );
         }
 
         if (!empty($settings['curlopts'])) {


### PR DESCRIPTION
Declares aperero/phpCAS ^1.6 in composer.json and updates CasAuthenticate class to include the client_service_name argument for phpCAS::client().

closes #5
maintenance