### PR TITLE
Fix default value and key for client_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ match variable names as used in the `apereo/phpcas`
 [example client usage](https://github.com/apereo/phpCAS/blob/master/docs/examples/example_simple.php).
 
 - `hostname` changed to `cas_host`
-- `port` changed to `cas_port
+- `port` changed to `cas_port`
 - `uri` changed to `cas_context`
 
 cakephp-casauth looks for input parameters using the old keys to try to remain backwards compatible.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For existing applications you can add the following to your composer.json file:
       }
     ],
     "require": {
-        "uazgraduatecollege/cakephp-casauth": "~1.0"
+        "uazgraduatecollege/cakephp-casauth": "~2.0"
     }
 ```
 
@@ -33,8 +33,9 @@ $this->Auth->config(
     'authenticate',
     [
         'CasAuth.Cas' => [
-            'hostname' => 'cas.mydomain.com',
-            'uri' => 'authpath'
+            'cas_host => 'cas.mydomain.com',
+            'cas_context => '/cas,
+            'client_service_name => 'https://clientapplication.otherdomain.com',
         ]
     ]
 );
@@ -48,8 +49,9 @@ $this->loadComponent(
     [
         'authenticate' => [
             'CasAuth.Cas' => [
-                'hostname' => 'cas.mydomain.com',
-                'uri' => 'authpath'
+                'cas_host => 'cas.mydomain.com',
+                'cas_context => '/cas,
+                'client_service_name => 'https://clientapplication.otherdomain.com',
             ]
         ]
     ]
@@ -57,26 +59,34 @@ $this->loadComponent(
 
 ```
 
-CAS parameters can be specified during `Auth->config` as above,
-or by writing to the "CAS" key in Configure::write, e.g.
-```php
-Configure::write('CAS.hostname', 'cas.myhost.com');
-Configure::write('CAS.port', 8443);
-```
-
 ## Parameters
 
-* **hostname** is required
-* **port** defaults to 443
-* **uri** defaults to '' (an empty string)
-* *client_name* (optional) defaults to `$_SERVER['SERVER_NAME']`
-* *debug* (optional) if true, then phpCAS will write debug info to logs/phpCAS.log
+* **cas_host** is required.
+* **cas_context** defaults to '' (an empty string)
+* *client_service_name* (optional) defaults to `$_SERVER['SERVER_NAME']`
+* *cas_port* defaults to 443
+* *debug* (optional) if true, then phpCAS will write debug info to your configured logger.
 * *cert_path* (optional) if set, then phpCAS will use the specified CA certificate file to verify the CAS server
 * *curlopts* (optional) key/value paired array of additional CURL parameters to pass through to phpCAS::setExtraCurlOption, e.g.
 
 ```php
 'curlopts' => [CURLOPT_PROXY => 'http://proxy:5543', CURLOPT_CRLF => true]
 ```
+
+### Note about parameter key changes
+
+Prior to release 2.0.0, several parameter used different keys.
+Release 2.0.0 updates `apereo/phpcas` to use at least version 1.6, which contains breaking changes.
+For better clarity, the previous parameter key names have been re-mapped to the new names, which
+match variable names as used in the `apereo/phpcas`
+[example client usage](https://github.com/apereo/phpCAS/blob/master/docs/examples/example_simple.php).
+
+- `hostname` changed to `cas_host`
+- `port` changed to `cas_port
+- `uri` changed to `cas_context`
+
+cakephp-casauth looks for input parameters using the old keys to try to remain backwards compatible.
+Your mileage may vary.
 
 ## License
 

--- a/src/Auth/CasAuthenticate.php
+++ b/src/Auth/CasAuthenticate.php
@@ -39,13 +39,16 @@ class CasAuthenticate extends BaseAuthenticate
     /**
      * $_defaultConfig
      *
-     * Default configuration array of variables passed to phpcas::client()
+     * Default configuration array of variables passed to phpcas::client().
+     * Example usage of these settings can be viewed in the apereo/phpcas documentation
+     * at https://github.com/apereo/phpCAS/blob/master/docs/examples/example_simple.php
      *
-     * @var $_defaultConfig['cas_host'] string The CAS host/domain name, eg. example.domain.com
-     * @var $_defaultConfig['cas_port'] string The CAS host/domain name, eg. example.domain.com
-     * @var $_defaultConfig['cas_context'] string The CAS host/domain name, eg. example.domain.com
-     * @var $_defaultConfig['client_service_name'] string Full URL of the client identified as protocol://host:port, eg. https://casclient.example.com
-     * @var $_defaultConfig['debug'] string The CAS host/domain name, eg. example.domain.com
+     * @var array $_defaultConfig The array of settings values to configure the CAS client
+     * @var string $_defaultConfig['cas_host'] The CAS host/domain name, eg. example.domain.com
+     * @var int $_defaultConfig['cas_port'] The port where CAS can be reached. Default 443
+     * @var string $_defaultConfig['cas_context'] The URL path that triggers authentication, eg. /cas
+     * @var string $_defaultConfig['client_service_name'] The base URL of the client service in protocol://domain:port format.
+     * @var bool $_defaultConfig['debug'] Whether debugging is on and should trigger log output. Default false
      */
     protected $_defaultConfig = [
         'cas_host' => null,
@@ -101,9 +104,9 @@ class CasAuthenticate extends BaseAuthenticate
         if (!phpCAS::isInitialized()) {
             phpCAS::client(
                 CAS_VERSION_2_0,
-                $settings['cas_host'],  // $cas_host
-                $settings['cas_port'],      // $cas_port
-                $settings['cas_context'],       // $cas_context
+                $settings['cas_host'], // $cas_host
+                $settings['cas_port'], // $cas_port
+                $settings['cas_context'], // $cas_context
                 $settings['client_service_name'] // $client_service_name
             );
         }
@@ -129,7 +132,7 @@ class CasAuthenticate extends BaseAuthenticate
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function authenticate(ServerRequest $request, Response $response)
     {
@@ -150,7 +153,7 @@ class CasAuthenticate extends BaseAuthenticate
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getUser(ServerRequest $request)
     {
@@ -176,8 +179,7 @@ class CasAuthenticate extends BaseAuthenticate
      * Log a user out. Interrupts initial call to AuthComponent logout
      * to handle CAS logout, which happens on separate CAS server
      *
-     * @param Event $event Auth.logout event
-     *
+     * @param \Cake\Event\Event $event Auth.logout event
      * @return void
      */
     public function logout(Event $event)


### PR DESCRIPTION
Updates the default value passed to phpCAS::client() service URL arg to include the protocol.

closes #7